### PR TITLE
edit history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ static/tag.json
 pnpm-lock.yaml
 package-lock.json
 .pnpm-debug.log
+static/edits.json
+static/crumbs.json

--- a/scripts/extract_structure.py
+++ b/scripts/extract_structure.py
@@ -1,6 +1,7 @@
-from pathlib import Path
 import json
 import frontmatter
+from subprocess import getstatusoutput as cli
+from pathlib import Path
 from md import parse_headings
 from util import url_from_route
 
@@ -12,6 +13,7 @@ This can be consumed in the client side javascript in order to create a site-map
 structure = { 'routes' : {} }
 page_structures = { 'pages' : {} }
 tag_db = { 'db' : {} }
+last_edits = { 'routes' : {} }
 
 route_path = Path('src/routes')
 
@@ -25,6 +27,26 @@ routes = [
 ]
 
 for route in routes:
+    status, cli_output = cli(f'git log -1 {str(route)}')
+    # Im horrible and im sorry 🚔 crime
+    output_split = cli_output.split('\n')
+    commit = output_split[0]
+    author = output_split[1]
+    modtime = output_split[2]
+    
+    last_commit = commit.split(' ')[1].lstrip().rstrip()
+    author_name = author.split(':')[1].split('<')[0].lstrip().rstrip()
+    last_edited = modtime.split(':', 1)[1].split('+')[0].lstrip().rstrip()
+    last_edited = last_edited.split(' ')[1:4]
+    last_edited = ' '.join(last_edited)
+
+    last_edits['routes'][url_from_route(route)] = {
+        'commit' : last_commit,
+        'author' : author_name,
+        'time' : last_edited,
+        'url' : str(route)
+    }
+
     url = Path('/'.join(list(route.parts[2:]))).with_suffix('')
     route_data = {}
 
@@ -61,3 +83,6 @@ with open('static/structure.json', 'w') as f:
 
 with open('static/pages.json', 'w') as f:
     json.dump(page_structures, f, indent=2)
+
+with open('static/edits.json', 'w') as f:
+    json.dump(last_edits, f, separators=(',', ':'))

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -1,6 +1,8 @@
 import { readable } from 'svelte/store';
 import s from '../../static/structure.json';
 import t from '../../static/tag.json';
+import e from '../../static/edits.json';
 
 export const structure = readable(s);
 export const tags = readable(t);
+export const edits = readable(e);

--- a/src/lib/components/EditHistory.svelte
+++ b/src/lib/components/EditHistory.svelte
@@ -1,0 +1,23 @@
+<script>
+	import { edits } from '$lib/app';
+	import { page } from '$app/stores';
+	const editHistory = $edits.routes[$page.path];
+    const source = `https://github.com/flucoma/learn-website/tree/main/${editHistory.url}`
+    const commit = `https://github.com/flucoma/learn-website/commit/${editHistory.commit}`
+</script>
+
+<div class="history">
+    <div class="last-edit">Last modified: { editHistory.time } by { editHistory.author }</div>
+    <a target='_blank' class='edit' href={commit}>Commit: { (editHistory.commit).slice(0,6) }</a>
+	<a target='_blank' class='edit' href={source}>Edit File on GitHub</a>
+</div>
+
+<style lang='scss'>
+    .history {
+        margin-top: 1em;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+        font-size: 0.65rem;
+    }
+</style>

--- a/src/lib/components/HR.svelte
+++ b/src/lib/components/HR.svelte
@@ -1,0 +1,9 @@
+<hr>
+
+<style>
+    hr {
+        height: 1px;
+        background-color: rgba(128, 128, 128, 0.187);
+        border: none;
+    }
+</style>

--- a/src/lib/layouts/overviews.svelte
+++ b/src/lib/layouts/overviews.svelte
@@ -2,6 +2,8 @@
 	export let title;
 	export let blurb;
 	export let tags;
+	import EditHistory from '$lib/components/EditHistory.svelte';
+	import HR from '$lib/components/HR.svelte';
 </script>
 
 <div class="title-box">
@@ -19,6 +21,10 @@
 </div>
 
 <slot />
+
+<HR />
+
+<EditHistory />
 
 <style lang="scss">
 	h1 {

--- a/src/lib/layouts/reference.svelte
+++ b/src/lib/layouts/reference.svelte
@@ -1,6 +1,8 @@
 <script>
 	export let title;
 	export let blurb;
+	import EditHistory from '$lib/components/EditHistory.svelte';
+	import HR from '$lib/components/HR.svelte';
 </script>
 
 <div class="title-box">
@@ -9,6 +11,10 @@
 </div>
 
 <slot />
+
+<HR />
+
+<EditHistory />
 
 <style lang="scss">
 	.blurb {


### PR DESCRIPTION
This adds edit history to each page derived from the `extract_stucture.py` script.

It also provides a link to edit the file directory on github, as well as to see who last changed them and when.
