### PR TITLE
Improved integration of flairs onto content

### DIFF
--- a/scripts/db.js
+++ b/scripts/db.js
@@ -12,15 +12,16 @@ glob('src/routes/**/*.svx', (err, routes) => {
 	routes = routes.filter((p) => path.basename(p) !== 'index.svx');
 
 	routes.forEach((route) => {
-		let section = route.split('/')[2];
+		const section = route.split('/')[2];
 
-		let url = urlFromRoute(route);
+		const url = urlFromRoute(route);
 		// Read the page in as a string
-		let data = fs.readFileSync(route, 'utf8');
+		const data = fs.readFileSync(route, 'utf8');
 		
 		// Get frontmatter
 		let fm = frontmatter(data).attributes;
         fm.url = url;
+		fm.section = section
 		
         db.docs.push(fm);
 	});

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -25,6 +25,7 @@ const search = new FuzzySearch(
     }
 );
 
-export const db = search;
+const db = search;
+export { db, docs }
 
 

--- a/src/lib/components/CardList.svelte
+++ b/src/lib/components/CardList.svelte
@@ -1,0 +1,71 @@
+<!-- 
+This component abstracts the rendering process for each "card" in madewith and overview sections.
+References are slightly different and use the ReferenceEntry component.
+-->
+
+<script>
+    import { docs } from '$lib/app.js';
+    import Flair from '$lib/components/Flair.svelte';
+    export let section = 'overviews';
+    
+    const items = docs.filter(x => x.section === section);
+</script>
+
+<div class='overview-list'>
+    {#each items as item}
+        <a class='entry' href={item.url}>
+            <div class='overview'>
+                <div class='top'>
+                    <h2 class='overview-title'>{item.title}</h2>
+                    <Flair flair={item.flair} />
+                </div>
+                <p class='overview-blurb'>{item.blurb}</p>
+            </div>
+        </a>
+    {/each}
+</div>
+
+<style lang='scss'>
+
+    .overview-list {
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+        a:hover {
+            background-color: transparent;
+            color: black;
+        }
+
+        .entry {
+            text-decoration: none;
+            color: black;
+            width: 100%;
+            max-width: 100%;
+
+            .top {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-between;
+
+                h2 {
+                    margin: 0;
+                }
+            }
+        }
+    }
+
+    .overview {
+        cursor: pointer;
+        padding: 0.4em;
+        box-shadow: 0 1px 1.5px 2px rgba(0, 0, 0, 0.1);
+        background-color: transparent;
+    }
+
+    .overview:hover {
+        scale: 1.03;
+    }
+
+    .overview-blurb {
+        color: grey;
+    }
+</style>

--- a/src/lib/components/Flair.svelte
+++ b/src/lib/components/Flair.svelte
@@ -18,6 +18,7 @@ class:event={flair==='event'}
         border-radius: 3px;
         color: white;
         padding: 3px;
+        height: 15px;
     }
 
     .event {

--- a/src/routes/madewithflucoma/index.svx
+++ b/src/routes/madewithflucoma/index.svx
@@ -3,58 +3,11 @@ layout: none
 ---
 
 <script>
-    import { info } from '$lib/app.js';
-    import { goto } from '$app/navigation';
+    import CardList from '$lib/components/CardList.svelte';
 </script>
 
 # Made with FluCoMa
 
 Made with FluCoMa highlights projects and practices where FluCoMa is used.
 
-<div class='overview-list'>
-    {#each $info.madewithflucoma as article}
-        {#if article.data}
-        <a class='entry' href={article.url}>
-            <div class='overview'>
-                <h2 class='overview-title'>{article.data.title}</h2>
-                <p class='overview-blurb'>{article.data.blurb}</p>
-            </div>
-        </a>
-        {/if}
-    {/each}
-</div>
-
-<style lang='scss'>
-
-    .overview-list {
-        display: flex;
-        flex-direction: column;
-        gap: 1em;
-        a:hover {
-            background: transparent;
-            color: black;
-        }
-
-        .entry {
-            text-decoration: none;
-            color: black;
-            width: 100%;
-            max-width: 100%;
-        }
-    }
-
-    .overview {
-        cursor: pointer;
-        padding: 0.4em;
-        box-shadow: 0 1px 1.5px 2px rgba(0, 0, 0, 0.1);
-        background-color: transparent;
-    }
-
-    .overview:hover {
-        scale: 1.03;
-    }
-
-    .overview-blurb {
-        color: grey;
-    }
-</style>
+<CardList section='madewithflucoma' />

--- a/src/routes/overviews/index.svx
+++ b/src/routes/overviews/index.svx
@@ -3,46 +3,11 @@ layout: none
 ---
 
 <script>
-    import { info } from '$lib/app.js';
-    import { goto } from '$app/navigation';
+    import CardList from '$lib/components/CardList.svelte';
 </script>
 
 # Overviews
 
-The overviews section hosts a variety of articles describing high-level problems in musicking with FluCoMa tools and the wider gamut of machine learning and machine listening technologies.
+The overviews section hosts a variety of articles, tutorials and explanations of concepts and workflows that integrate with the FluCoMa tools and the wider gamut of machine learning and machine listening technologies.
 
-<div class='overview-list'>
-    {#each $info.overviews as overview}
-        {#if overview.data}
-        <div class='overview' on:click={ () => goto(overview.url) }>
-        <h2 class='overview-title'>{overview.data.title}</h2>
-        <p class='overview-blurb'>{overview.data.blurb}</p>
-        </div>
-        {/if}
-    {/each}
-</div>
-
-
-<style>
-    .overview-list {
-        display: flex;
-        flex-direction: column;
-        gap: 1em;
-    }
-
-    .overview {
-        cursor: pointer;
-        padding: 0.4em;
-        box-shadow: 0 1px 1.5px 2px rgba(0, 0, 0, 0.1);
-        background-color: transparent;
-    }
-
-    .overview:hover {
-        scale: 1.03;
-    }
-
-    .overview-blurb {
-        color: grey;
-    }
-</style>
-
+<CardList section='overviews' />


### PR DESCRIPTION
Adds flair support for the cards that appear in main sections. This necessitated an overhaul _anyway_ of how these cards are drawn as a template which makes the code not only smaller but easier to follow and extend.
