### PR TITLE
Update to new SvelteKit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 [![Deployment](https://github.com/flucoma/learn/actions/workflows/deploy.yml/badge.svg)](https://github.com/flucoma/learn/actions/workflows/deploy.yml)
 
-To run this website you will need a package manager for js/node such as `pnpm`, `yarn` or `npm` and a Python 3+ installation.
-
-You will also need to have a working virtual environment, or be willing to pollute the global space with the packages in `requirements.txt`.
-
-`pip install -r requirements.txt`
+To run this website you will need a package manager for js/node such as `pnpm`, `yarn` or `npm`.
 
 ## Run Locally
 

--- a/src/lib/components/Crumbs.svelte
+++ b/src/lib/components/Crumbs.svelte
@@ -27,7 +27,7 @@
 		path.forEach((p, i) => {
 			let sanitisedText = '';
 			if (i >= 1) {
-				sanitisedText = $breadcrumbs[$page.path];
+				sanitisedText = $breadcrumbs[$page.url.pathname];
 			} else {
 				sanitisedText = formatCrumb(p);
 			}
@@ -37,7 +37,7 @@
 		});
 		return d;
 	}
-	$: crumbs = splitPath($page.path);
+	$: crumbs = splitPath($page.url.pathname);
 </script>
 
 <!-- Breadcrumbs -->

--- a/src/lib/components/EditHistory.svelte
+++ b/src/lib/components/EditHistory.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { edits } from '$lib/app.js';
 	import { page } from '$app/stores';
-	const editHistory = $edits[$page.path];
+	const editHistory = $edits[$page.url.pathname];
 	const source: string = `https://github.com/flucoma/learn-website/tree/main/${editHistory.url}`;
 	const commit: string = `https://github.com/flucoma/learn-website/commit/${editHistory.commit}`;
 </script>

--- a/src/lib/components/TOC.svelte
+++ b/src/lib/components/TOC.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/stores';
 	import { structure } from '$lib/app.js';
 
-	$: headings = $structure[$page.path] || [];
+	$: headings = $structure[$page.url.pathname] || [];
 </script>
 
 {#if headings.length > 0}

--- a/src/routes/search/[query].svelte
+++ b/src/routes/search/[query].svelte
@@ -1,8 +1,8 @@
 <script context="module">
-	export async function load({ page }) {
+	export async function load({ params }) {
 		return {
 			props: {
-				query: page.params.query
+				query: params.query
 			}
 		};
 	}


### PR DESCRIPTION
- use $page.url.pathname
- use param object in dynamic route (api update)

Various small changes will eventually break the site, so I'm updating them now to get ahead of the game. This mainly refers to how the $page object was changed in [208](https://github.com/sveltejs/kit/blob/master/packages/kit/CHANGELOG.md#100-next208) onwards.
