### PR TITLE
[Enhance] Remove tags from view of articles

### DIFF
--- a/src/lib/layouts/madewithflucoma.svelte
+++ b/src/lib/layouts/madewithflucoma.svelte
@@ -12,13 +12,13 @@
 		{blurb}
 	</p>
 
-	<div class="tagtainer">
+	<!-- <div class="tagtainer">
 		{#each tags as tag}
 			<a class="tag" href="/search/{tag}">
 				{tag}
 			</a>
 		{/each}
-	</div>
+	</div> -->
 </div>
 
 <slot />

--- a/src/lib/layouts/overviews.svelte
+++ b/src/lib/layouts/overviews.svelte
@@ -12,13 +12,13 @@
 		{blurb}
 	</p>
 
-	<div class="tagtainer">
+	<!-- <div class="tagtainer">
 		{#each tags as tag}
 			<a class="tag" href="/search/{tag}">
 				{tag}
 			</a>
 		{/each}
-	</div>
+	</div> -->
 </div>
 
 <slot />


### PR DESCRIPTION
The tags are currently not very useful and won't be till a full document search is implemented.

As such, this PR removes them from the layouts for now.﻿
