### PR TITLE
[Enhance] Neutral Content Fonts

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -16,11 +16,15 @@
 }
 
 html {
-	font-family: var(--font);
+	font-family: -apple-system, BlinkMacSystemFont, sans-serif, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue';
 }
 
 body {
 	margin: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	font-family: var(--font);
 }
 
 p,

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -79,6 +79,7 @@
 	}
 
 	.nav-link {
+		font-family: var(--font);
 		margin-top: auto;
 		margin-bottom: auto;
 		text-align: center;


### PR DESCRIPTION
Only using overpass is not only ugly, it might not render properly. For most of the content we should use the system sans-serif font.﻿
