### PR TITLE
[Enhance] GitHub style slugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"d3": "^7.3.0",
 		"front-matter": "^4.0.2",
 		"fuzzy-search": "^3.2.1",
+		"github-slugger": "^1.4.0",
 		"glob": "^7.2.0",
 		"hastscript": "^7.0.2",
 		"js-search": "^2.0.0",

--- a/scripts/metadata.js
+++ b/scripts/metadata.js
@@ -1,10 +1,13 @@
 import glob from 'glob';
 import path from 'path';
 import fs from 'fs';
+import GithubSlugger from 'github-slugger';
 import frontmatter from 'front-matter';
 import { extractGit } from './git.js';
-import { sanitiseHashLink, urlFromRoute } from './util.js';
+import { urlFromRoute } from './util.js';
 import { markdown } from 'markdown';
+
+const slugger = new GithubSlugger();
 
 let info = {};
 let structure = {};
@@ -32,7 +35,8 @@ glob('src/**/*.svx', (err, routes) => {
 
 		tree.forEach((el) => {
 			if (el[0] === 'header' && el[1].level === 2) {
-				let hashPart = sanitiseHashLink(el[2]);
+				slugger.reset();
+				let hashPart = slugger.slug(el[2]);
 				structure[url].push({
 					url: `${url}#${hashPart}`,
 					text: el[2]


### PR DESCRIPTION
Instead of rolling my own link cleanser, I've leveraged the same one that the [rehype plugin](https://github.com/rehypejs/rehype-slug) uses under the hood. This ensures parity.
