### PR TITLE
[Enhance] Related articles under table of contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ static/crumbs.json
 scripts/__pycache__
 static/info.json
 static/db.json
+static/related.json

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"hastscript": "^7.0.2",
 		"konva": "^8.3.2",
 		"markdown": "^0.5.0",
+		"markdown-link-extractor": "^1.3.1",
 		"mdsvex": "^0.9.8",
 		"meyda": "^5.3.0",
 		"numpy-parser": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"name": "learn",
 	"version": "0.0.1",
 	"scripts": {
-		"dev": "node scripts/metadata.js && node scripts/db.js && svelte-kit dev --host",
-		"build": "node scripts/metadata.js && node scripts/db.js && svelte-kit build",
+		"dev": "node scripts/metadata.js && node scripts/db.js && node scripts/related.js && svelte-kit dev --host",
+		"build": "node scripts/metadata.js && node scripts/db.js && node scripts/related.js && svelte-kit build",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore --ignore-pattern '!**/*.{scd,maxpat}' .",

--- a/scripts/related.js
+++ b/scripts/related.js
@@ -1,0 +1,48 @@
+import glob from 'glob';
+import path from 'path';
+import fs from 'fs';
+import frontmatter from 'front-matter';
+import { urlFromRoute } from './util.js';
+import markdownLinkExtractor from 'markdown-link-extractor';
+
+let db = {};
+
+glob('src/routes/*(reference|madewithflucoma|overviews)/*.svx', (err, routes) => {
+	routes = routes.filter((p) => path.basename(p) !== 'index.svx');
+
+	routes.forEach((route) => {
+		const section = route.split('/')[2];
+
+		const url = urlFromRoute(route);
+		// Read the page in as a string
+		const data = fs.readFileSync(route, 'utf8');
+		let links = markdownLinkExtractor(data, false);
+		links = links.filter(x => x.startsWith('/'));
+		links = [...new Set(links)];
+
+		let fm = frontmatter(data).attributes;
+
+		let payload = [];
+
+		links.forEach(link => {
+			const length = link.split('/').filter(x => x != '').length; // filter out index.svx type situations
+			if (length > 1 && link !== url) {
+				const branchUrl = `src/routes${link}.svx`;
+				const branch = fs.readFileSync(branchUrl, 'utf8');
+				const branchFm = frontmatter(branch).attributes;
+				payload.push({
+					title: branchFm.title,
+					url: link,
+					flair: branchFm.flair,
+				})
+			}
+		})
+
+		db[url] = payload
+	});
+
+	// Write out results
+	fs.writeFile('static/related.json', JSON.stringify(db), 'utf8', () => {
+		console.log('Relationships file written to static/related.json')
+	});
+});

--- a/src/lib/components/Related.svelte
+++ b/src/lib/components/Related.svelte
@@ -1,0 +1,120 @@
+<script>
+	import { page } from '$app/stores';
+    import related from '../../../static/related.json';
+    $: links = related[$page.url.pathname] || [];
+    $: references = links.filter(x => x.flair === 'reference');
+    $: articles = links.filter(x => x.flair === 'article');
+    $: tutorials = links.filter(x => x.flair === 'tutorial');
+</script>
+
+
+{#if links.length > 0}
+<div>
+    <h3 class='related'>Related Links</h3>
+
+    {#if articles.length > 0}
+    
+    <div class="category">
+        <div class='flaired-title'>
+            <div class="flair article" />
+            <div>Articles</div>
+        </div>
+
+        <div class='links'>
+            {#each articles as link}
+            <a class='link' href="{link.url}">{link.title}</a>
+            {/each}
+        </div>
+    </div>
+    {/if}
+
+    {#if tutorials.length > 0}
+    <div class="category">
+        <div class='flaired-title'>
+            <div class="flair tutorial" />
+            <div>Articles</div>
+        </div>
+
+        <div class='links'>
+            {#each tutorials as link}
+            <a class='link' href="{link.url}">{link.title}</a>
+            {/each}
+        </div>
+    </div>
+    {/if}
+
+    {#if references.length > 0}
+    <div class="category">
+        <div class='flaired-title'>
+            <div class="flair reference" />
+            <div class='title'>Reference</div>
+        </div>
+
+        <div class='links'>
+            {#each references as link}
+            <a class='link' href="{link.url}">{link.title}</a>
+            {/each}
+        </div>
+    </div>
+    {/if}
+</div>
+{/if}
+
+<style>
+    .category {
+        margin-bottom: 1em;
+    }
+    
+    .flaired-title {
+        display: grid;
+        grid-template-columns: 10px max-content;
+        justify-content: left;
+        align-items: center;
+        margin-bottom: 0.5em;
+        font-family: var(--font);
+        font-weight: bold;
+        gap: 0.25em;
+    }
+
+    .links {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+    }
+
+    .link {
+        text-decoration: none;
+		font-size: 0.8rem;
+    }
+
+    .link:hover {
+        color: var(--med-blue);
+        background-color: transparent;
+        text-decoration: underline;
+    }
+
+    .flair {
+        width: 10px;
+        height: 10px;
+    }
+
+    .event {
+		background-color: rgb(235, 161, 23);
+	}
+
+	.article {
+		background-color: var(--light-blue);
+	}
+
+	.reference {
+		background-color: forestgreen;
+	}
+
+	.podcast {
+		background-color: palevioletred;
+	}
+
+	.tutorial {
+		background-color: rgba(102, 103, 171, 255);
+	}
+</style>

--- a/src/lib/components/TOC.svelte
+++ b/src/lib/components/TOC.svelte
@@ -1,32 +1,34 @@
 <script>
 	import { page } from '$app/stores';
 	import { structure } from '$lib/app.js';
+	import Related from '$lib/components/Related.svelte'
 
 	$: headings = $structure[$page.url.pathname] || [];
 </script>
 
 {#if headings.length > 0}
 <nav class="container">
-	<div class="toc">Table of Contents</div>
-	<div class="headings">
-		{#each headings as h}
+	<div>
+		<h3 class="toc">Table of Contents</h3>
+		<div class="headings">
+			{#each headings as h}
 			<a target='_self' href={h.url}>{h.text}</a>
-		{/each}
+			{/each}
+		</div>
 	</div>
+	<Related />
 </nav>
 {/if}
 
+
 <style lang="postcss">
 	.container {
+		display: flex;
+		flex-direction: column;
+		gap: 1em;
 		position: fixed;
 		z-index: 1;
 		max-width: 23ch;
-	}
-
-	.toc {
-		font-size: 1rem;
-		margin-bottom: 1em;
-		font-weight: bold;
 	}
 
 	.headings {
@@ -43,6 +45,10 @@
 	@media (max-width: 1200px) {
 		.container {
 			position: relative;
+			display: grid;
+			grid-template-columns: auto auto;
+			max-width: 100%;
+			width: 100%;
 		}
 	}
 </style>

--- a/src/lib/widget/BufScale.svelte
+++ b/src/lib/widget/BufScale.svelte
@@ -1,0 +1,96 @@
+<script lang='ts'>
+    import { scale } from '$lib/util.js';
+    let input: number[] = [1, 2, 3, 4, 5];
+    let output: number[] = [];
+    let iMin = 1;
+    let iMax = 5;
+    let oMin = 0;
+    let oMax = 1;
+    
+    $: output = input.map(x => scale(x, [iMin, iMax], [oMin, oMax]));
+</script>
+
+<div class="container">
+    <form class='controls'>
+        <h3>Minima and Maxima</h3>
+        <div>
+            <label for='imin'>Input Minimum</label>
+            <input type="number" id="imin" bind:value={iMin}/>
+        </div>
+        
+        <div>
+            <label for='imax'>Input Maximum</label>
+            <input type="number" id="imax" bind:value={iMax}/>
+        </div>
+        
+        <div>
+            <label for='imax'>Output Minimum</label>
+            <input type="number" id="omin" bind:value={oMin}/>
+        </div>
+        
+        <div>
+            <label for='imax'>Output Maximum</label>
+            <input type="number" id="omax" bind:value={oMax}/>
+        </div>
+    </form>
+    
+    <div class="data">
+        <h3>Data</h3>
+        <div class='data-view'>
+            <span>
+                Input Data:
+            </span>
+            <span>
+                {#each input as i}
+                { i } &nbsp
+                {/each}
+            </span>
+        </div>
+        
+        <div class='data-view'>
+            <span>
+                Output Data:
+            </span>
+            <span>
+                {#each output as o}
+                { o.toFixed(2) } &nbsp
+                {/each}
+            </span>
+        </div>
+    </div>
+    
+</div>
+
+<style>
+    .container {
+        display: flex;
+        flex-direction: row;
+        margin-top: 1em;
+    }
+    .controls {
+        display: flex;
+        flex-direction: column;
+        width: max-content;
+        margin-right: 4em;
+        gap: 0.5em;
+    }
+    .controls > div {
+        display: grid;
+        grid-template-columns: 13ch 5ch;
+    }
+
+    .data {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+    }
+
+    .data-view {    
+        display: grid;
+        grid-template-columns: 1ch auto;
+    }
+
+    .data-view > span:nth-child(1) {
+        font-weight: bold;
+    }
+</style>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -25,7 +25,8 @@
 			<slot />
 		</main>
 
-		<div class="empty-right" />
+		<div class="related">
+		</div>
 	</div>
 	<Footer />
 </div>
@@ -60,8 +61,8 @@
 		height: max-content;
 	}
 
-	.empty-right {
-		grid-area: empty-right;
+	.related {
+		grid-area: related;
 		width: 25ch;
 	}
 
@@ -69,7 +70,7 @@
 	@media (min-width: 1200px) {
 		.content {
 			grid-template-columns: auto min(var(--max-text-width), 100%) auto;
-			grid-template-areas: 'navigation main empty-right';
+			grid-template-areas: 'navigation main related';
 		}
 	}
 
@@ -81,7 +82,11 @@
 				'main';
 		}
 
-		.empty-right {
+		.navigation {
+			width: 100%;
+		}
+
+		.related {
 			display: none;
 		}
 	}


### PR DESCRIPTION
This adds a "related" section under the table of contents. It basically pulls any internal links out of the document at build time and then creates a small json bundle that can be accessed client side. 

My questions are, is this useful? How can we make it even more useful? I imagine `seealso` can become a part of this when we eventually get the DOCS producing raw JSON.