### PR TITLE
[Enhance] Markdown Label Format

### DIFF
--- a/src/lib/components/Image.svelte
+++ b/src/lib/components/Image.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { markdown } from 'markdown';
+
 	export let src: string = '';
 	export let alt: string = '';
 	export let label: string = '';
@@ -10,7 +12,7 @@
 		<img loading="lazy" {alt} {src} />
 	</a>
 	<figcaption class="label">
-		{label}
+		{@html markdown.toHTML(label)}
 	</figcaption>
 </figure >
 


### PR DESCRIPTION
Allows you to use markdown format in Image labels:

```sv
<Image
src="/reference/hpss/03_median_filter_on_a_row.png"
label="[hello](https://google.com) One row (FFT bin) of the spectrogram. x axis = time; y axis = magnitudes; median filter length = 51"
/>
```﻿
