### PR TITLE
[Fix] Search Focus Specificity

### DIFF
--- a/src/lib/components/Search.svelte
+++ b/src/lib/components/Search.svelte
@@ -48,28 +48,28 @@
 		if (e.key === '/' && e.metaKey) {
 			focusSearch()
 		}
-
-		if (e.key === 'ArrowUp') {
-			e.preventDefault();
-			focusedEntry -= 1;
-			updateFocus()
-		}
-
-		if (e.key === 'ArrowDown') {
-			e.preventDefault();
-			focusedEntry += 1;
-			updateFocus()
-		}
-		
-		if (e.key === 'Enter') {
-			if (focusedEntry !== -1) {
-				clickResult(filteredResults[focusedEntry].url)
-				e.preventDefault();
-			}
-		}
-
 		if (e.key === 'Escape') {
 			blurSearch();
+		}
+		if (focused) {
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				focusedEntry -= 1;
+				updateFocus()
+			}
+
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				focusedEntry += 1;
+				updateFocus()
+			}
+			
+			if (e.key === 'Enter') {
+				if (focusedEntry !== -1) {
+					clickResult(filteredResults[focusedEntry].url)
+					e.preventDefault();
+				}
+			}
 		}
 	}
 	$: filteredResults = results.slice(0, 8).filter(x => x !== null);


### PR DESCRIPTION
Handlers for key presses were happening globally, rather than when the search bar was focused. This means the user could invisibly navigate up and down the list of entries, and actually navigate away from the page when when the search drop down was not preset.﻿
