### PR TITLE
[Fix] Pin sveltekit version to 321

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "next",
-		"@sveltejs/kit": "next",
+		"@sveltejs/kit": "1.0.0-next.321",
 		"@typescript-eslint/eslint-plugin": "^4.33.0",
 		"@typescript-eslint/parser": "^4.33.0",
 		"autoprefixer": "^10.4.4",


### PR DESCRIPTION
Various issues have cropped up in next, so this pins the svelte version to 321.﻿
