### PR TITLE
[Fix] Use FluCoMa kmeans package

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"seedrandom": "~2.4.4",
 		"svelte-bricks": "^0.1.6",
 		"svelte-select": "^4.4.7",
-		"tf-kmeans": "^0.0.3",
+		"@flucoma/tf-kmeans": "^0.0.3",
 		"tone": "^14.7.77",
 		"umap-js": "^1.3.3",
 		"waveform-data": "^4.3.0",

--- a/src/lib/widget/KMeans.svelte
+++ b/src/lib/widget/KMeans.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import KMeans from 'tf-kmeans';
+    import KMeans from '@flucoma/tf-kmeans';
     import * as tf from '@tensorflow/tfjs';
     import * as d3 from 'd3';
     import { onMount } from 'svelte';


### PR DESCRIPTION
We were previously using https://www.npmjs.com/package/tf-kmeans for the KMeans algorithm explanation.

It is seemingly unmaintained and had some dependency issues so I forked it and made it work with our code.
