### PR TITLE
[Fix] Related links parsing with #

### DIFF
--- a/scripts/related.js
+++ b/scripts/related.js
@@ -40,6 +40,7 @@ glob('src/routes/*(reference|learn|explore)/*.svx', (err, routes) => {
 		let payload = [];
 		links.forEach(link => {
 			const length = link.split('/').filter(x => x != '').length; // filter out index.svx type situations
+			link = link.split('#')[0]
 			if (length > 1 && link !== url) {
 				add(link, backreference);
 				const branch = fs.readFileSync(`src/routes${link}.svx`, 'utf8');


### PR DESCRIPTION
Fixes situations where you want to use # in a link to go to an anchor.
