### PR TITLE
attempt at adding the link

### DIFF
--- a/src/routes/(content)/getting-started/+page.svelte
+++ b/src/routes/(content)/getting-started/+page.svelte
@@ -5,7 +5,13 @@
 	import ContentGallery from './ContentGallery.svelte';
 </script>
 
+<br>
+<br>
+<br>
 <h1>Getting Started</h1>
+<h2>Installation</h2>
+Start by installing the package in your creative coding environement. Max users can download the latest public version via the built-in package manager. To install the latest copy, see the detailled [installation help pages](/installation).
+<br>
 <h2>Tutorials</h2>
 
 <div class="widgets">

--- a/src/routes/(content)/getting-started/+page.svelte
+++ b/src/routes/(content)/getting-started/+page.svelte
@@ -10,7 +10,9 @@
 <br>
 <h1>Getting Started</h1>
 <h2>Installation</h2>
-Start by installing the package in your creative coding environement. Max users can download the latest public version via the built-in package manager. To install the latest copy, see the detailled [installation help pages](/installation).
+<p class='installation-description'>
+	Start by installing the package in your creative coding environement. Max users can download the latest public version via the built-in package manager. To install the latest copy, see the detailled <a href='/installation'>installation instructions</a>.
+</p>
 <br>
 <h2>Tutorials</h2>
 
@@ -43,5 +45,10 @@ Start by installing the package in your creative coding environement. Max users 
 		gap: 1em;
 		justify-content: center;
 		margin-bottom: 3em;
+	}
+
+	.installation-description {
+		max-width: max(70ch, 50%);
+		margin: 0 auto;
 	}
 </style>


### PR DESCRIPTION
after a few users complained they couldn't find a link to installations, I tried to add it to the home page of 'getting started'

I strangly cannot use the links at that level, and I wonder why.  help?