### PR TITLE
turned on `fluid.bufnmf~` resynthmode in help file

### DIFF
--- a/static/learn/bufnmf/bufnmf-overview-example.maxpat
+++ b/static/learn/bufnmf/bufnmf-overview-example.maxpat
@@ -3,8 +3,8 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 2,
-			"revision" : 1,
+			"minor" : 5,
+			"revision" : 5,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -57,7 +57,6 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 307.5, 379.599976062774658, 365.0, 27.0 ],
-					"presentation_linecount" : 2,
 					"text" : "4. select which component you want to hear"
 				}
 
@@ -70,7 +69,6 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 238.5, 333.699968278408051, 342.0, 27.0 ],
-					"presentation_linecount" : 2,
 					"text" : "3. turn on playback for the resynth buffer"
 				}
 
@@ -222,10 +220,10 @@
 					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 1,
-					"numoutlets" : 3,
-					"outlettype" : [ "bang", "float", "" ],
-					"patching_rect" : [ 370.5, 163.600005984306335, 334.0, 35.0 ],
-					"text" : "fluid.bufnmf~ @source drums @components 3 @activations activations @bases bases @resynth resynth"
+					"numoutlets" : 4,
+					"outlettype" : [ "", "", "", "" ],
+					"patching_rect" : [ 370.5, 163.600005984306335, 341.0, 35.0 ],
+					"text" : "fluid.bufnmf~ @source drums @components 3 @activations activations @bases bases @resynthmode 1 @resynth resynth"
 				}
 
 			}
@@ -419,18 +417,13 @@
 
 			}
  ],
-		"dependency_cache" : [ 			{
-				"name" : "fluid.bufnmf~.mxo",
-				"type" : "iLaX"
-			}
- ],
 		"autosave" : 0,
 		"styles" : [ 			{
 				"name" : "max6box",
 				"default" : 				{
-					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
+					"accentcolor" : [ 0.8, 0.839216, 0.709804, 1.0 ],
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.5 ],
-					"accentcolor" : [ 0.8, 0.839216, 0.709804, 1.0 ]
+					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 				}
 ,
 				"parentstyle" : "",
@@ -448,17 +441,17 @@
 , 			{
 				"name" : "max6message",
 				"default" : 				{
-					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 					"bgfillcolor" : 					{
-						"type" : "gradient",
+						"angle" : 270.0,
+						"autogradient" : 0,
+						"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 						"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 						"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-						"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-						"angle" : 270.0,
 						"proportion" : 0.39,
-						"autogradient" : 0
+						"type" : "gradient"
 					}
-
+,
+					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 				}
 ,
 				"parentstyle" : "max6box",


### PR DESCRIPTION
Turned on `fluid.bufnmf~` resynthmode in the max help file on BufNMF learn page.