### PR TITLE
Make popover nav consume more space

### DIFF
--- a/src/lib/components/PopoverNav.svelte
+++ b/src/lib/components/PopoverNav.svelte
@@ -44,7 +44,7 @@
 		left: 0;
 		background-color: white;
 		opacity: 1;
-		width: min(400px, 50%);
+		width: min(600px, 80%);
 		height: 100vh;
 		text-align: left;
 		padding: 1em 2em;

--- a/src/lib/components/cards/Landing.svelte
+++ b/src/lib/components/cards/Landing.svelte
@@ -26,6 +26,12 @@
 		margin: 0;
 	}
 
+	.container > :global(p) {
+		margin: 0;
+		margin-bottom: 0.25em;
+		margin-top: 0.25em;
+	}
+
 	.linkout {
 		display: grid;
 		grid-template-columns: auto auto;


### PR DESCRIPTION
The popover nav in mobile formats is currently very small. This makes it larger by default but still responsive.
