### PR TITLE
Fix MFCC ref page "Drop Zero" buttons wrong way round

### DIFF
--- a/src/routes/(content)/reference/mfcc/DropZero.svelte
+++ b/src/routes/(content)/reference/mfcc/DropZero.svelte
@@ -119,8 +119,8 @@
 	<canvas id="filter" bind:this={canvas} />
 	<div class="controls">
 		<Audio {...audioSpec} bind:audio on:play={play} on:pause={pause} />
-		<Button {...zero} on:click={() => dropzero(1)} />
-		<Button {...one} on:click={() => dropzero(0)} />
+		<Button {...zero} on:click={() => dropzero(0)} />
+		<Button {...one} on:click={() => dropzero(1)} />
 	</div>
 </div>
 


### PR DESCRIPTION
MFCC reference page's drop zero example has the "startCoeff = 0" and "startCoeff = 1" buttons the wrong way round, they do the opposite of what they say.