### PR TITLE
Fix MFCC ref page "Drop Zero" analyser not always starting with audio playback

### DIFF
--- a/src/routes/(content)/reference/mfcc/DropZero.svelte
+++ b/src/routes/(content)/reference/mfcc/DropZero.svelte
@@ -96,8 +96,8 @@
 					chart.update();
 				}
 			});
-			analyser.start();
 		}
+		analyser.start();
 	};
 
 	const pause = () => {


### PR DESCRIPTION
MFCC reference page's drop zero example doesn't start analyser with audio playback after the first time it's paused, requiring a page refresh. Seems like the `analyser.start();` line is simply placed one curly bracket too early.