### PR TITLE
Downgrade node versions to 18

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
 
             - uses: actions/setup-node@v3
               with:
-                node-version: 19
+                node-version: 18
 
             - name: install pnpm
               run: npm i -g pnpm

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
 
             - uses: actions/setup-node@v3
               with:
-                node-version: 19
+                node-version: 18
 
             - name: install pnpm
               run: npm i -g pnpm


### PR DESCRIPTION
Many packages are still capped at version 18 of node. This downgrades the deployment environments to 18.
