### PR TITLE
navigation to/from the podcast page

### DIFF
--- a/src/lib/components/front-page/WelcomeBanner.svelte
+++ b/src/lib/components/front-page/WelcomeBanner.svelte
@@ -9,8 +9,8 @@
 		<div id="buttons">
 			<WelcomeButton url='/learn/getting-started' text='Getting Started'/>
 			<WelcomeButton url='/learn' text='Learn'/>
-			<WelcomeButton url='/explore' text='Explore'/>
 			<WelcomeButton url='/reference' text='Reference'/>
+			<WelcomeButton url='/explore' text='Explore'/>
 		</div>
 	</div>
 	<div id='welcome-right'>

--- a/src/lib/components/podcasts/Hero.svelte
+++ b/src/lib/components/podcasts/Hero.svelte
@@ -1,5 +1,5 @@
-<img id='podcast-banner' src='/img/podcast_banner.jpg' alt='FluCoMa podcast logo'/>
-<h2>FluCoMa Learn Podcast</h2>
+<img id='podcast-banner' src='/img/podcast_banner.jpg' alt='FluCoMa Podcast logo'/>
+<h2><a href="/">FluCoMa Learn</a> Podcast</h2>
 <div>FluCoMa Learn Podcasts are an intermittent series of interviews with artists discussing their work using and experimenting with machine learning and machine listening.</div>
 <div class="links">
 	<a class="podcasts-link raisedbox" href='https://podcasts.apple.com/gb/podcast/flucoma-learn-podcasts/id1678385732'>


### PR DESCRIPTION
adding a return link to the podcast, and reordering the tags of the landing page so they are in the same order as the menu bar

this is a bit crude but the podcast page layout is not the same and there was no way to come back. Ideally it would have the same header than the rest of learn, with all the menus, but I didn't manage to do that...